### PR TITLE
feat: add /health and /readiness endpoints for monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Legacy API path deprecation middleware with optional redirect via `RENTABOT_LEGACY_REDIRECT` env var
 - Deprecation headers (`Deprecation: true`, `Link: <alternate>`) on legacy `/rentabot/api/v1.0/` endpoints
 - Pre-commit hook for automatic code formatting and linting with ruff
+- `/health` endpoint for basic service monitoring and uptime checks
+- `/readiness` endpoint for Kubernetes readiness probes
 
 ### Changed
 - **BREAKING**: Tag format changed from space-separated to comma-separated (e.g., `"tag1,tag2,tag3"` instead of `"tag1 tag2 tag3"`)
-- **BREAKING**: Minimum Python version requirement updated to 3.10 (from 3.9, which reached EOL in October 2024)
+- **BREAKING**: Minimum Python version requirement updated to 3.10 (from 3.9, which reached EOL in October 31st 2025)
 - Logging uses standard logging module instead of daiquiri.
 - Replaced `threading.Lock` with `asyncio.Lock` for better async compatibility.
 - Fixed typo in `get_all_resources` function name.

--- a/rentabot/main.py
+++ b/rentabot/main.py
@@ -159,6 +159,31 @@ async def index(request: Request):
     )
 
 
+# - [ Health & Status ] -------------------------------------------------------
+
+
+@app.get("/health")
+async def health():
+    """
+    Health check endpoint for monitoring.
+
+    Returns 200 OK if the service is running.
+    Useful for basic uptime monitoring and load balancer health checks.
+    """
+    return {"status": "ok"}
+
+
+@app.get("/readiness")
+async def readiness():
+    """
+    Readiness check endpoint for Kubernetes.
+
+    Returns 200 OK if the service is ready to accept traffic.
+    Kubernetes uses this to determine if the pod should receive requests.
+    """
+    return {"status": "ready"}
+
+
 # - [ API ] ------------------------------------------------------------------
 
 # - [ GET : Access to resources information ]

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -36,3 +36,31 @@ def test_startup_without_resource_descriptor():
         # Restore original environment variable
         if original_value is not None:
             os.environ["RENTABOT_RESOURCE_DESCRIPTOR"] = original_value
+
+
+def test_health_endpoint(app):
+    """
+    Title: Test /health endpoint
+
+    Given: The application is running
+    When: Requesting the /health endpoint
+    Then: A 200 OK status is returned with status "ok"
+    """
+    response = app.get("/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+
+
+def test_readiness_endpoint(app):
+    """
+    Title: Test /readiness endpoint
+
+    Given: The application is running
+    When: Requesting the /readiness endpoint
+    Then: A 200 OK status is returned with status "ready"
+    """
+    response = app.get("/readiness")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ready"


### PR DESCRIPTION
Add health check endpoints for service monitoring and Kubernetes deployments:
- /health: Basic uptime check returning {"status": "ok"}
- /readiness: Kubernetes readiness probe returning {"status": "ready"}

Both endpoints return 200 OK when the service is operational. Useful for load balancers, monitoring systems, and Kubernetes health checks.
