### PR TITLE
refactor: consolidate duplicate exception handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - **BREAKING**: Tag format changed from space-separated to comma-separated (e.g., `"tag1,tag2,tag3"` instead of `"tag1 tag2 tag3"`)
 - **BREAKING**: Minimum Python version requirement updated to 3.10 (from 3.9, which reached EOL in October 31st 2025)
+- Consolidated duplicate exception handlers into single handler following DRY principles
 - Logging uses standard logging module instead of daiquiri.
 - Replaced `threading.Lock` with `asyncio.Lock` for better async compatibility.
 - Fixed typo in `get_all_resources` function name.

--- a/rentabot/main.py
+++ b/rentabot/main.py
@@ -24,9 +24,7 @@ from rentabot.controllers import (
     unlock_resource,
 )
 from rentabot.exceptions import (
-    InvalidLockToken,
     ResourceAlreadyLocked,
-    ResourceAlreadyUnlocked,
     ResourceException,
     ResourceNotFound,
 )
@@ -272,24 +270,9 @@ async def lock_by_criterias(
 
 @app.exception_handler(ResourceException)
 async def resource_exception_handler(request: Request, exc: ResourceException):
-    return JSONResponse(status_code=exc.status_code, content=exc.dict)
+    """
+    Consolidated exception handler for all ResourceException subclasses.
 
-
-@app.exception_handler(ResourceNotFound)
-async def resource_not_found_handler(request: Request, exc: ResourceNotFound):
-    return JSONResponse(status_code=exc.status_code, content=exc.dict)
-
-
-@app.exception_handler(ResourceAlreadyLocked)
-async def resource_already_locked_handler(request: Request, exc: ResourceAlreadyLocked):
-    return JSONResponse(status_code=exc.status_code, content=exc.dict)
-
-
-@app.exception_handler(ResourceAlreadyUnlocked)
-async def resource_already_unlocked_handler(request: Request, exc: ResourceAlreadyUnlocked):
-    return JSONResponse(status_code=exc.status_code, content=exc.dict)
-
-
-@app.exception_handler(InvalidLockToken)
-async def invalid_lock_token_handler(request: Request, exc: InvalidLockToken):
+    Handles: ResourceNotFound, ResourceAlreadyLocked, ResourceAlreadyUnlocked, InvalidLockToken
+    """
     return JSONResponse(status_code=exc.status_code, content=exc.dict)


### PR DESCRIPTION
Reduce code duplication by using single exception handler for all ResourceException subclasses. This simplifies maintenance and follows DRY principles.

- Removed 4 duplicate exception handlers (ResourceNotFound, ResourceAlreadyLocked, ResourceAlreadyUnlocked, InvalidLockToken)
- Kept single base ResourceException handler that handles all subclasses via inheritance
- Reduced exception handling code from 26 lines to 6 lines
- Removed unused exception imports
- All tests pass with consolidated handler
