### PR TITLE
refactor: replace custom .dict property with to_dict() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **BREAKING**: Tag format changed from space-separated to comma-separated (e.g., `"tag1,tag2,tag3"` instead of `"tag1 tag2 tag3"`)
 - **BREAKING**: Minimum Python version requirement updated to 3.10 (from 3.9, which reached EOL in October 31st 2025)
 - Consolidated duplicate exception handlers into single handler following DRY principles
+- Replaced custom `.dict` property with standard `to_dict()` method in exception classes
 - Logging uses standard logging module instead of daiquiri.
 - Replaced `threading.Lock` with `asyncio.Lock` for better async compatibility.
 - Fixed typo in `get_all_resources` function name.

--- a/rentabot/exceptions.py
+++ b/rentabot/exceptions.py
@@ -19,8 +19,8 @@ class ResourceException(Exception):
         self.message = message
         self.payload = payload
 
-    @property
-    def dict(self):
+    def to_dict(self):
+        """Serialize exception to dictionary."""
         rv = dict(self.payload or ())
         rv["message"] = self.message
         return rv

--- a/rentabot/main.py
+++ b/rentabot/main.py
@@ -275,4 +275,4 @@ async def resource_exception_handler(request: Request, exc: ResourceException):
 
     Handles: ResourceNotFound, ResourceAlreadyLocked, ResourceAlreadyUnlocked, InvalidLockToken
     """
-    return JSONResponse(status_code=exc.status_code, content=exc.dict)
+    return JSONResponse(status_code=exc.status_code, content=exc.to_dict())


### PR DESCRIPTION
Replace @property dict with standard to_dict() method in exception classes for better clarity and to avoid shadowing Python builtin.

- Changed ResourceException.dict property to to_dict() method
- Updated exception handler to call to_dict() instead of accessing .dict
- Added docstring to to_dict() method
- Improves code readability and follows Python naming conventions
- All tests pass
